### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "astro-build.astro-vscode"
+            ]
+        }
+    },
+    "remoteUser": "root",
+    "containerEnv": {
+        "ASTRO_TELEMETRY_DISABLED": "true"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 .output/
 .astro
+.pnpm-store/
 
 # dependencies
 node_modules/


### PR DESCRIPTION
This devcontainer can only be used with docker in Rootless mode. (would require to change the `remoteUser` from `root` to `vscode` if the docker daemon is running as root).